### PR TITLE
Do not include podman and certs when ensure is not present

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,8 +15,10 @@ class iop_advisor_engine (
   Enum['present', 'absent'] $ensure = 'present',
   Stdlib::HTTPUrl $foreman_url = "https://${facts['networking']['fqdn']}"
 ) {
-  include podman
-  include certs::iop_advisor_engine
+  if $ensure == 'present' {
+    include podman
+    include certs::iop_advisor_engine
+  }
 
   $service_name = 'iop-advisor-engine'
   $log_dir = "/var/log/${service_name}"


### PR DESCRIPTION
When ensure is absent on a first run, this will still include podman and cause packages to get installed. And certificates to be generated. 

If ensure is flipped from present to absent, I do not believe we should pass absent to the podman class, as that might remove RPMs being used for some other reason.